### PR TITLE
feat: add agent debug logging

### DIFF
--- a/guideline/project_structure.md
+++ b/guideline/project_structure.md
@@ -12,6 +12,7 @@ project/
     snapshot/
       snapshot.json                # roles, status hash, env
       needs.json                   # present only if action_required occurred
+    log/                           # role-specific debug logs (when CODEX_DEBUG)
     .camel_sessions/               # per-project session root for all roles
 ```
 

--- a/run.py
+++ b/run.py
@@ -1,18 +1,49 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 #!/usr/bin/env python3
 import argparse
+import os
 import subprocess
 import sys
-import os
 from pathlib import Path
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Run interactive Broker (Codex CLI)")
-    parser.add_argument("requirement", nargs="?", default="requirement.md", help="Path to requirement.md (default: requirement.md)")
-    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug mode to print agent progress")
+    parser = argparse.ArgumentParser(
+        description="Run interactive Broker (Codex CLI)"
+    )
+    parser.add_argument(
+        "requirement",
+        nargs="?",
+        default="requirement.md",
+        help="Path to requirement.md (default: requirement.md)",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Enable debug mode to print agent progress",
+    )
     args = parser.parse_args()
 
-    broker_cli = Path(__file__).parent / "examples" / "usecases" / "codex_cli_broker_mcp" / "broker_cli.py"
+    broker_cli = (
+        Path(__file__).parent
+        / "examples"
+        / "usecases"
+        / "codex_cli_broker_mcp"
+        / "broker_cli.py"
+    )
     if not broker_cli.exists():
         print(f"Broker CLI not found: {broker_cli}")
         sys.exit(1)
@@ -20,7 +51,6 @@ def main():
     # Prefer a modern Python runtime for the child process (>=3.10)
     py = sys.executable
     try:
-        import platform as _platform
         v_info = sys.version_info
         if v_info < (3, 10):
             # Prefer project local venv if present
@@ -41,8 +71,9 @@ def main():
     except Exception:
         pass
 
+    debug = bool(args.debug or os.environ.get("CODEX_DEBUG"))
     cmd = [py, str(broker_cli), "-r", str(Path(args.requirement).resolve())]
-    if args.debug:
+    if debug:
         cmd.append("-d")
     try:
         # Ensure repo root is importable by child script (for `camel` package)
@@ -50,7 +81,7 @@ def main():
         repo_root = str(Path(__file__).parent.resolve())
         old_pp = env.get("PYTHONPATH", "")
         env["PYTHONPATH"] = f"{repo_root}:{old_pp}" if old_pp else repo_root
-        if args.debug:
+        if debug:
             env["CODEX_DEBUG"] = "1"
         subprocess.run(cmd, check=True, env=env)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- support global CODEX_DEBUG and CLI flag in run and MCP servers
- write role-specific debug logs under project log/
- document log/ directory in project structure guideline

## Testing
- `pre-commit run --files run.py examples/usecases/codex_cli_broker_mcp/broker_cli.py examples/usecases/codex_cli_boss_mcp/boss_server.py examples/usecases/codex_cli_hello_world_mcp/worker_server.py guideline/project_structure.md` *(fails: Cannot find implementation or library stub for module named "sklearn.metrics")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b863dccad08333ae03a9518a311265